### PR TITLE
 Implement format display instead of ToString

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,8 @@
 //!
 //! ## What does a parsable BNF grammar look like?
 //!
-//! The following grammar from the [Wikipedia page on Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Example)
+//! The following grammar from the [Wikipedia page on Backus-Naur form]
+//! (https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Example)
 //! exemplifies a compatible grammar after adding ';' characters to indicate the end of a producion.
 //!
 //! ```text

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,39 +1,39 @@
 //! bnf, a library for parsing Backus–Naur form context-free grammars
-//! 
+//!
 //! Inspired by the JavaScript library [prettybnf](https://github.com/dhconnelly/prettybnf)
-//! 
-//! 
+//!
+//!
 //! The code is available on [Github](https://github.com/snewt/bnf)
-//! 
+//!
 //! ## What does a parsable BNF grammar look like?
-//! 
+//!
 //! The following grammar from the [Wikipedia page on Backus-Naur form](https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Example)
 //! exemplifies a compatible grammar after adding ';' characters to indicate the end of a producion.
-//! 
+//!
 //! ```text
 //! <postal-address> ::= <name-part> <street-address> <zip-part>;
-//! 
+//!
 //!         <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
 //!                     | <personal-part> <name-part>;
-//! 
+//!
 //!     <personal-part> ::= <initial> "." | <first-name>;
-//! 
+//!
 //!     <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
-//! 
+//!
 //!         <zip-part> ::= <town-name> "," <state-code> <ZIP-code> <EOL>;
-//! 
+//!
 //! <opt-suffix-part> ::= "Sr." | "Jr." | <roman-numeral> | "";
 //!     <opt-apt-num> ::= <apt-num> | "";
 //! ```
-//! 
+//!
 //! ## Output
 //! Take the following grammar to be input to this library's `parse` function:
 //!
 //! ```text
 //! <A> ::= <B> | "C";
-//! <B> ::= "D" | "E"; 
+//! <B> ::= "D" | "E";
 //! ```
-//! 
+//!
 //! The output is a `Grammar` object representing a tree that looks like this:
 //!
 //! ```text
@@ -84,45 +84,46 @@
 //!     ]
 //! }
 //! ```
-//! 
+//!
 //! ## Example
-//! 
+//!
 //! ```rust
 //! extern crate bnf;
-//! 
+//!
 //! fn main() {
 //!     let input =
 //!         "<postal-address> ::= <name-part> <street-address> <zip-part>;
-//! 
+//!
 //!               <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
 //!                             | <personal-part> <name-part>;
-//! 
+//!
 //!           <personal-part> ::= <initial> \".\" | <first-name>;
-//! 
+//!
 //!          <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
-//! 
+//!
 //!                <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;
-//! 
+//!
 //!         <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";
 //!             <opt-apt-num> ::= <apt-num> | \"\";";
-//! 
+//!
 //!     let grammar = bnf::parse(input);
 //!     println!("{:#?}", grammar);
 //! }
 //! ```
 //!
 
-#[macro_use] extern crate nom;
+#[macro_use]
+extern crate nom;
 mod parsers;
 mod reports;
 pub mod node;
-use node::{Grammar};
-use nom::{IResult};
+use node::Grammar;
+use nom::IResult;
 
 /// Parse a BNF grammer
 pub fn parse(input: &str) -> Grammar {
     match parsers::grammar(input.as_bytes()) {
-        IResult::Done(_,o) => return o,
+        IResult::Done(_, o) => return o,
         IResult::Error(e) => {
             reports::report_error(e);
         }

--- a/src/node.rs
+++ b/src/node.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 
 
 #[derive(PartialEq, Debug, Clone)]
@@ -7,11 +8,11 @@ pub enum Term {
     Nonterminal(String),
 }
 
-impl ToString for Term {
-    fn to_string(&self) -> String {
-        match self {
-            &Term::Terminal(ref s) => return format!("\"{}\"", s),
-            &Term::Nonterminal(ref s) => return format!("<{}>", s),
+impl fmt::Display for Term {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            Term::Terminal(ref s) => write!(f, "\"{}\"", s),
+            Term::Nonterminal(ref s) => write!(f, "<{}>", s),
         }
     }
 }
@@ -34,13 +35,15 @@ impl Expression {
     }
 }
 
-impl ToString for Expression {
-    fn to_string(&self) -> String {
-        self.terms
+impl fmt::Display for Expression {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let display = self.terms
             .iter()
             .map(|s| s.to_string())
             .collect::<Vec<_>>()
-            .join(" ")
+            .join(" ");
+
+        write!(f, "{}", display)
     }
 }
 
@@ -66,9 +69,10 @@ impl Production {
     }
 }
 
-impl ToString for Production {
-    fn to_string(&self) -> String {
-        format!(
+impl fmt::Display for Production {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
             "{} ::= {};",
             self.lhs.to_string(),
             self.rhs
@@ -99,9 +103,10 @@ impl Grammar {
     }
 }
 
-impl ToString for Grammar {
-    fn to_string(&self) -> String {
-        format!(
+impl fmt::Display for Grammar {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
             "{}\n",
             self.productions
                 .iter()

--- a/src/node.rs
+++ b/src/node.rs
@@ -25,12 +25,12 @@ pub struct Expression {
 impl Expression {
     #[allow(dead_code)]
     pub fn new() -> Expression {
-        Expression { terms: vec![], }
+        Expression { terms: vec![] }
     }
 
     #[allow(dead_code)]
     pub fn from_parts(v: Vec<Term>) -> Expression {
-        Expression { terms: v, }
+        Expression { terms: v }
     }
 }
 
@@ -38,7 +38,9 @@ impl ToString for Expression {
     fn to_string(&self) -> String {
         self.terms
             .iter()
-            .map(|s| s.to_string()).collect::<Vec<_>>().join(" ")
+            .map(|s| s.to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
     }
 }
 
@@ -52,12 +54,15 @@ pub struct Production {
 impl Production {
     #[allow(dead_code)]
     pub fn new() -> Production {
-        Production { lhs: Term::Nonterminal(String::new()), rhs: vec![], }
+        Production {
+            lhs: Term::Nonterminal(String::new()),
+            rhs: vec![],
+        }
     }
 
     #[allow(dead_code)]
     pub fn from_parts(t: Term, e: Vec<Expression>) -> Production {
-        Production { lhs: t, rhs: e, }
+        Production { lhs: t, rhs: e }
     }
 }
 
@@ -70,7 +75,8 @@ impl ToString for Production {
                 .iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()
-                .join(" | "))
+                .join(" | ")
+        )
     }
 }
 
@@ -82,12 +88,14 @@ pub struct Grammar {
 
 impl Grammar {
     pub fn new() -> Grammar {
-        Grammar { productions: vec![], }
+        Grammar {
+            productions: vec![],
+        }
     }
 
     #[allow(dead_code)]
     pub fn from_parts(v: Vec<Production>) -> Grammar {
-        Grammar { productions: v, }
+        Grammar { productions: v }
     }
 }
 
@@ -99,6 +107,7 @@ impl ToString for Grammar {
                 .iter()
                 .map(|s| s.to_string())
                 .collect::<Vec<_>>()
-                .join("\n"))
+                .join("\n")
+        )
     }
 }

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,5 +1,5 @@
 
-use node::{Grammar, Production, Expression, Term,};
+use node::{Expression, Grammar, Production, Term};
 
 named!(pub terminal< &[u8], Term >,
     do_parse!(
@@ -38,7 +38,7 @@ named!(pub grammar< &[u8], Grammar >,
         eof!() >>
         (Grammar::from_parts(prods))
     )
-);    
+);
 
 #[cfg(test)]
 mod tests {
@@ -47,8 +47,7 @@ mod tests {
     fn construct_terminal_tuple() -> (Term, String) {
         let terminal_pattern = "\"terminal pattern\"";
         let terminal_value = "terminal pattern";
-        let terminal_object =
-            Term::Terminal(String::from(terminal_value));
+        let terminal_object = Term::Terminal(String::from(terminal_value));
 
         (terminal_object, String::from(terminal_pattern))
     }
@@ -56,15 +55,16 @@ mod tests {
     #[test]
     fn terminal_match() {
         let terminal_tuple = construct_terminal_tuple();
-        assert_eq!(terminal_tuple.0,
-            terminal(terminal_tuple.1.as_bytes()).unwrap().1);
+        assert_eq!(
+            terminal_tuple.0,
+            terminal(terminal_tuple.1.as_bytes()).unwrap().1
+        );
     }
 
     fn construct_nonterminal_tuple() -> (Term, String) {
         let nonterminal_pattern = "<nonterminal-pattern>";
         let nonterminal_value = "nonterminal-pattern";
-        let nonterminal_object =
-            Term::Nonterminal(String::from(nonterminal_value));
+        let nonterminal_object = Term::Nonterminal(String::from(nonterminal_value));
 
         (nonterminal_object, String::from(nonterminal_pattern))
     }
@@ -72,16 +72,17 @@ mod tests {
     #[test]
     fn nonterminal_match() {
         let nonterminal_tuple = construct_nonterminal_tuple();
-        assert_eq!(nonterminal_tuple.0,
-            nonterminal(nonterminal_tuple.1.as_bytes()).unwrap().1);
+        assert_eq!(
+            nonterminal_tuple.0,
+            nonterminal(nonterminal_tuple.1.as_bytes()).unwrap().1
+        );
     }
 
     fn construct_expression_tuple() -> (Expression, String) {
         let nonterminal_tuple = construct_nonterminal_tuple();
         let terminal_tuple = construct_terminal_tuple();
         let expression_pattern = nonterminal_tuple.1 + &terminal_tuple.1 + "|";
-        let expression_object =
-            Expression::from_parts(vec![nonterminal_tuple.0, terminal_tuple.0]);
+        let expression_object = Expression::from_parts(vec![nonterminal_tuple.0, terminal_tuple.0]);
 
         (expression_object, String::from(expression_pattern))
     }
@@ -89,24 +90,25 @@ mod tests {
     #[test]
     fn expression_match() {
         let expression_tuple = construct_expression_tuple();
-        assert_eq!(expression_tuple.0,
-            expression(expression_tuple.1.as_bytes()).unwrap().1);
+        assert_eq!(
+            expression_tuple.0,
+            expression(expression_tuple.1.as_bytes()).unwrap().1
+        );
     }
 
     fn construct_production_tuple() -> (Production, String) {
         let expression_tuple = construct_expression_tuple();
         let nonterminal_tuple = construct_nonterminal_tuple();
         let terminal_tuple = construct_nonterminal_tuple();
-        let production_pattern = 
-            nonterminal_tuple.1 + 
-            "::=" + 
-            &expression_tuple.1 + 
-            &terminal_tuple.1 + ";";
-        let production_object =
-            Production::from_parts(
-                nonterminal_tuple.0, 
-                vec![expression_tuple.0.clone(), 
-                Expression::from_parts(vec![terminal_tuple.0])]);
+        let production_pattern =
+            nonterminal_tuple.1 + "::=" + &expression_tuple.1 + &terminal_tuple.1 + ";";
+        let production_object = Production::from_parts(
+            nonterminal_tuple.0,
+            vec![
+                expression_tuple.0.clone(),
+                Expression::from_parts(vec![terminal_tuple.0]),
+            ],
+        );
 
         (production_object, String::from(production_pattern))
     }
@@ -114,18 +116,19 @@ mod tests {
     #[test]
     fn production_match() {
         let production_tuple = construct_production_tuple();
-        assert_eq!(production_tuple.0,
-            production(production_tuple.1.as_bytes()).unwrap().1);
+        assert_eq!(
+            production_tuple.0,
+            production(production_tuple.1.as_bytes()).unwrap().1
+        );
     }
 
     fn construct_grammar_tuple() -> (Grammar, String) {
-
         let production_tuple = construct_production_tuple();
         let grammar_pattern = production_tuple.1.clone() + &production_tuple.1;
-        let grammar_object =
-            Grammar::from_parts(
-                vec![construct_production_tuple().0.clone(), 
-                construct_production_tuple().0]);
+        let grammar_object = Grammar::from_parts(vec![
+            construct_production_tuple().0.clone(),
+            construct_production_tuple().0,
+        ]);
 
         (grammar_object, String::from(grammar_pattern))
     }
@@ -134,7 +137,9 @@ mod tests {
     fn grammar_match() {
         let grammar_tuple = construct_grammar_tuple();
         println!("{:#?}", grammar_tuple.1);
-        assert_eq!(grammar_tuple.0,
-            grammar(grammar_tuple.1.as_bytes()).unwrap().1);
+        assert_eq!(
+            grammar_tuple.0,
+            grammar(grammar_tuple.1.as_bytes()).unwrap().1
+        );
     }
 }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -5,20 +5,28 @@ pub fn report_error(err: Err<&[u8], u32>) {
     match err {
         Err::Code(_) => {
             println!("Parsing error: Unknown origin");
-        },
+        }
         Err::Node(_, n) => {
             println!("Parsing error: Unknown origin");
-            for e in n { report_error(e); }
-        },
-        Err::Position(_,p) => {
-            println!("Parsing error: When input is {:?}",
-            String::from_utf8_lossy(p).into_owned());
-        },
-        Err::NodePosition(_,p,n) => {
-            println!("Parsing error: When input is {:?}",
-            String::from_utf8_lossy(p).into_owned());
-            for e in n { report_error(e); }
-        },
+            for e in n {
+                report_error(e);
+            }
+        }
+        Err::Position(_, p) => {
+            println!(
+                "Parsing error: When input is {:?}",
+                String::from_utf8_lossy(p).into_owned()
+            );
+        }
+        Err::NodePosition(_, p, n) => {
+            println!(
+                "Parsing error: When input is {:?}",
+                String::from_utf8_lossy(p).into_owned()
+            );
+            for e in n {
+                report_error(e);
+            }
+        }
     }
 }
 
@@ -27,12 +35,17 @@ pub fn report_incomplete(needed: Needed, actual: usize) {
         Needed::Unknown => {
             println!(
                 "Data error: insufficient size, expectation unknown, \
-                found {:?} bytes", actual);
-        },
+                 found {:?} bytes",
+                actual
+            );
+        }
         Needed::Size(s) => {
             println!(
                 "Data error: insufficient size, expected {:?} bytes \
-                but found {:?}", s, actual);
-        },
+                 but found {:?}",
+                s,
+                actual
+            );
+        }
     }
 }


### PR DESCRIPTION
Previously the BNF types implemented the ToString trait. However the
rust convention is to implement fmt::Display instead because it covers
wider use cases and automatically implements the ToString trait as well.
Now the types support format as well as to_string.

Apologies also that is change is bundled with rustfmt changes. I could not get vscode to play nice with formatting.