### PR TITLE
Switch reporters to using display format

### DIFF
--- a/src/reports.rs
+++ b/src/reports.rs
@@ -14,14 +14,14 @@ pub fn report_error(err: Err<&[u8], u32>) {
         }
         Err::Position(_, p) => {
             println!(
-                "Parsing error: When input is {:?}",
-                String::from_utf8_lossy(p).into_owned()
+                "Parsing error: When input is {}",
+                String::from_utf8_lossy(p)
             );
         }
         Err::NodePosition(_, p, n) => {
             println!(
-                "Parsing error: When input is {:?}",
-                String::from_utf8_lossy(p).into_owned()
+                "Parsing error: When input is {}",
+                String::from_utf8_lossy(p)
             );
             for e in n {
                 report_error(e);
@@ -35,14 +35,14 @@ pub fn report_incomplete(needed: Needed, actual: usize) {
         Needed::Unknown => {
             println!(
                 "Data error: insufficient size, expectation unknown, \
-                 found {:?} bytes",
+                 found {} bytes",
                 actual
             );
         }
         Needed::Size(s) => {
             println!(
-                "Data error: insufficient size, expected {:?} bytes \
-                 but found {:?}",
+                "Data error: insufficient size, expected {} bytes \
+                 but found {}",
                 s,
                 actual
             );


### PR DESCRIPTION
It seems strange to me to rely on debug printing for anything user facing. Then again, maybe in this case since it is error reporting, it is acceptable? Small change, but honestly could be convinced to go either way.