### PR TITLE
Maint/issue 14 end production

### DIFF
--- a/src/node.rs
+++ b/src/node.rs
@@ -69,7 +69,7 @@ impl fmt::Display for Production {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,
-            "{} ::= {};",
+            "{} ::= {}",
             self.lhs.to_string(),
             self.rhs
                 .iter()

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -22,7 +22,7 @@ macro_rules! look_ahead(
 named!(pub prod_lhs< &[u8], Term >, 
     do_parse!(
             nt: ws!(delimited!(tag!("<"), take_until!(">"), ws!(tag!(">")))) >>
-            ret: tag!("::=") >> 
+            ret: ws!(tag!("::=")) >> 
             (Term::Nonterminal(String::from_utf8_lossy(nt).into_owned()))
     )
 );

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -5,7 +5,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn validate_display() {
+    fn validate_terminated_display() {
         let input =
             "<postal-address> ::= <name-part> <street-address> <zip-part>;
 
@@ -34,4 +34,35 @@ mod tests {
 
         assert_eq!(grammar.to_string(), display_output);
     }
+
+    #[test]
+    fn validate_nonterminated_display() {
+        let input =
+            "<postal-address> ::= <name-part> <street-address> <zip-part>
+
+                <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+                                | <personal-part> <name-part>
+
+            <personal-part> ::= <initial> \".\" | <first-name>
+
+            <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
+
+                <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>
+
+            <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
+                <opt-apt-num> ::= <apt-num> | \"\"";
+
+        let display_output = 
+            "<postal-address> ::= <name-part> <street-address> <zip-part>;\n\
+             <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>;\n\
+             <personal-part> ::= <initial> \".\" | <first-name>;\n\
+             <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;\n\
+             <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;\n\
+             <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";\n\
+             <opt-apt-num> ::= <apt-num> | \"\";\n";        
+        
+        let grammar = bnf::parse(input);        
+
+        assert_eq!(grammar.to_string(), display_output);
+    }    
 }

--- a/tests/display.rs
+++ b/tests/display.rs
@@ -22,14 +22,14 @@ mod tests {
                 <opt-apt-num> ::= <apt-num> | \"\";";
 
         let display_output = 
-            "<postal-address> ::= <name-part> <street-address> <zip-part>;\n\
-             <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>;\n\
-             <personal-part> ::= <initial> \".\" | <first-name>;\n\
-             <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;\n\
-             <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;\n\
-             <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";\n\
-             <opt-apt-num> ::= <apt-num> | \"\";\n";        
-        
+            "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
+             <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
+             <personal-part> ::= <initial> \".\" | <first-name>\n\
+             <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
+             <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
+             <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
+             <opt-apt-num> ::= <apt-num> | \"\"\n";          
+
         let grammar = bnf::parse(input);        
 
         assert_eq!(grammar.to_string(), display_output);
@@ -53,14 +53,14 @@ mod tests {
                 <opt-apt-num> ::= <apt-num> | \"\"";
 
         let display_output = 
-            "<postal-address> ::= <name-part> <street-address> <zip-part>;\n\
-             <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>;\n\
-             <personal-part> ::= <initial> \".\" | <first-name>;\n\
-             <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;\n\
-             <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;\n\
-             <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";\n\
-             <opt-apt-num> ::= <apt-num> | \"\";\n";        
-        
+            "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
+             <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
+             <personal-part> ::= <initial> \".\" | <first-name>\n\
+             <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
+             <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
+             <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
+             <opt-apt-num> ::= <apt-num> | \"\"\n";        
+
         let grammar = bnf::parse(input);        
 
         assert_eq!(grammar.to_string(), display_output);

--- a/tests/nodes.rs
+++ b/tests/nodes.rs
@@ -1,5 +1,5 @@
 extern crate bnf;
-use bnf::node::{Term, Expression, Production, Grammar};
+use bnf::node::{Expression, Grammar, Production, Term};
 
 #[cfg(test)]
 mod tests {
@@ -23,17 +23,17 @@ mod tests {
     #[test]
     fn new_productions() {
         let lhs1: Term = Term::Nonterminal(String::from("STRING A"));
-        let rhs1: Expression = Expression::from_parts(
-            vec![
-                Term::Terminal(String::from("STRING B")),
-                Term::Nonterminal(String::from("STRING C"))]);
+        let rhs1: Expression = Expression::from_parts(vec![
+            Term::Terminal(String::from("STRING B")),
+            Term::Nonterminal(String::from("STRING C")),
+        ]);
         let p1: Production = Production::from_parts(lhs1, vec![rhs1]);
 
         let lhs2: Term = Term::Nonterminal(String::from("STRING A"));
-        let rhs2: Expression = Expression::from_parts(
-            vec![
-                Term::Terminal(String::from("STRING B")),
-                Term::Nonterminal(String::from("STRING C"))]);
+        let rhs2: Expression = Expression::from_parts(vec![
+            Term::Terminal(String::from("STRING B")),
+            Term::Nonterminal(String::from("STRING C")),
+        ]);
         let mut p2: Production = Production::new();
         p2.lhs = lhs2;
         p2.rhs = vec![rhs2];
@@ -44,17 +44,17 @@ mod tests {
     #[test]
     fn new_grammars() {
         let lhs1: Term = Term::Nonterminal(String::from("STRING A"));
-        let rhs1: Expression = Expression::from_parts(
-            vec![
-                Term::Terminal(String::from("STRING B")),
-                Term::Nonterminal(String::from("STRING C"))]);
+        let rhs1: Expression = Expression::from_parts(vec![
+            Term::Terminal(String::from("STRING B")),
+            Term::Nonterminal(String::from("STRING C")),
+        ]);
         let p1: Production = Production::from_parts(lhs1, vec![rhs1]);
 
         let lhs2: Term = Term::Nonterminal(String::from("STRING A"));
-        let rhs2: Expression = Expression::from_parts(
-            vec![
-                Term::Terminal(String::from("STRING B")),
-                Term::Nonterminal(String::from("STRING C"))]);
+        let rhs2: Expression = Expression::from_parts(vec![
+            Term::Terminal(String::from("STRING B")),
+            Term::Nonterminal(String::from("STRING C")),
+        ]);
         let p2: Production = Production::from_parts(lhs2, vec![rhs2]);
 
         let mut g1: Grammar = Grammar::new();


### PR DESCRIPTION
A couple notes on this PR that aren't captured in that last commit message. 
1. Since the `;` is optional now, I removed it from the Display output, my preference is to default to not showing it.
2. I added a `nom`y macro of my own. The behavior was interested in was processing an undefined amount of input without actually consuming any of it. nom's `peek` macro lets you "look ahead" but if it finds the pattern it consumes it.