### PR TITLE
Remove unnecessary integration test scope & macros

### DIFF
--- a/tests/display.rs
+++ b/tests/display.rs
@@ -1,64 +1,61 @@
 extern crate bnf;
 
-#[cfg(test)]
-mod tests {
-    use bnf::Grammar;
+use bnf::Grammar;
 
-    #[test]
-    fn validate_terminated_display() {
-        let input = "<postal-address> ::= <name-part> <street-address> <zip-part>;
+#[test]
+fn validate_terminated_display() {
+    let input = "<postal-address> ::= <name-part> <street-address> <zip-part>;
 
-                <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
-                                | <personal-part> <name-part>;
+            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+                            | <personal-part> <name-part>;
 
-            <personal-part> ::= <initial> \".\" | <first-name>;
+        <personal-part> ::= <initial> \".\" | <first-name>;
 
-            <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
+        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>;
 
-                <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;
+            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>;
 
-            <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";
-                <opt-apt-num> ::= <apt-num> | \"\";";
+        <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\";
+            <opt-apt-num> ::= <apt-num> | \"\";";
 
-        let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
-                              <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
-                              <personal-part> ::= <initial> \".\" | <first-name>\n\
-                              <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
-                              <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
-                              <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
-                              <opt-apt-num> ::= <apt-num> | \"\"\n";
+    let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
+                            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
+                            <personal-part> ::= <initial> \".\" | <first-name>\n\
+                            <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
+                            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
+                            <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
+                            <opt-apt-num> ::= <apt-num> | \"\"\n";
 
-        let grammar = Grammar::from_str(input).unwrap();
+    let grammar = Grammar::from_str(input).unwrap();
 
-        assert_eq!(grammar.to_string(), display_output);
-    }
+    assert_eq!(grammar.to_string(), display_output);
+}
 
-    #[test]
-    fn validate_nonterminated_display() {
-        let input = "<postal-address> ::= <name-part> <street-address> <zip-part>
+#[test]
+fn validate_nonterminated_display() {
+    let input = "<postal-address> ::= <name-part> <street-address> <zip-part>
 
-                <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
-                                | <personal-part> <name-part>
+            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL>
+                            | <personal-part> <name-part>
 
-            <personal-part> ::= <initial> \".\" | <first-name>
+        <personal-part> ::= <initial> \".\" | <first-name>
 
-            <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
+        <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>
 
-                <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>
+            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>
 
-            <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
-                <opt-apt-num> ::= <apt-num> | \"\"";
+        <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"
+            <opt-apt-num> ::= <apt-num> | \"\"";
 
-        let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
-                              <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
-                              <personal-part> ::= <initial> \".\" | <first-name>\n\
-                              <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
-                              <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
-                              <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
-                              <opt-apt-num> ::= <apt-num> | \"\"\n";
+    let display_output = "<postal-address> ::= <name-part> <street-address> <zip-part>\n\
+                            <name-part> ::= <personal-part> <last-name> <opt-suffix-part> <EOL> | <personal-part> <name-part>\n\
+                            <personal-part> ::= <initial> \".\" | <first-name>\n\
+                            <street-address> ::= <house-num> <street-name> <opt-apt-num> <EOL>\n\
+                            <zip-part> ::= <town-name> \",\" <state-code> <ZIP-code> <EOL>\n\
+                            <opt-suffix-part> ::= \"Sr.\" | \"Jr.\" | <roman-numeral> | \"\"\n\
+                            <opt-apt-num> ::= <apt-num> | \"\"\n";
 
-        let grammar = Grammar::from_str(input).unwrap();
+    let grammar = Grammar::from_str(input).unwrap();
 
-        assert_eq!(grammar.to_string(), display_output);
-    }
+    assert_eq!(grammar.to_string(), display_output);
 }

--- a/tests/from_str.rs
+++ b/tests/from_str.rs
@@ -1,9 +1,8 @@
 extern crate bnf;
 
-#[cfg(test)]
 mod std_trait {
     use std::str::FromStr;
-    
+
     use bnf::{Expression, Grammar, Production, Term};
 
     fn std_str_trait<T: FromStr>(_: T, input: &str) {
@@ -15,7 +14,7 @@ mod std_trait {
     fn expression_from_str() {
         let input = "\"😵\" \"😋\" \"😉\"";
         let expression = Expression::new();
-        std_str_trait(expression, input)        
+        std_str_trait(expression, input)
     }
 
     #[test]
@@ -35,20 +34,19 @@ mod std_trait {
 
     #[test]
     fn terminal_from_str() {
-        let input = "\"👏 \"";        
+        let input = "\"👏 \"";
         let terminal = Term::Terminal(String::new());
         std_str_trait(terminal, input)
     }
 
     #[test]
     fn nonterminal_from_str() {
-        let input = "<🤘>";        
+        let input = "<🤘>";
         let nonterminal = Term::Nonterminal(String::new());
         std_str_trait(nonterminal, input)
     }
 }
 
-#[cfg(test)]
 mod custom_trait {
     use bnf::{Expression, Grammar, Production, Term};
 
@@ -56,7 +54,7 @@ mod custom_trait {
     fn expression_from_str() {
         let input = "\"😵\" \"😋\" \"😉\"";
         let expression = Expression::from_str(input);
-        assert!(expression.is_ok())      
+        assert!(expression.is_ok())
     }
 
     #[test]
@@ -76,14 +74,14 @@ mod custom_trait {
 
     #[test]
     fn terminal_from_str() {
-        let input = "\"👏 \"";        
+        let input = "\"👏 \"";
         let terminal = Term::from_str(input);
         assert!(terminal.is_ok())
     }
 
     #[test]
     fn nonterminal_from_str() {
-        let input = "<🤘>";        
+        let input = "<🤘>";
         let nonterminal = Term::from_str(input);
         assert!(nonterminal.is_ok())
     }

--- a/tests/generate.rs
+++ b/tests/generate.rs
@@ -1,58 +1,53 @@
 extern crate bnf;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[test]
+fn parse_from_bnf_for_bnf() {
+    // Modified version of BNF for BNF from
+    // https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Further_examples
+    let bnf_for_bnf: &str = "<syntax>        ::= <rule> | <rule> <syntax>
+        <rule>           ::= <opt-whitespace> \"<\" <rule-name> \">\"
+                            <opt-whitespace> \"::=\" <opt-whitespace>
+                            <expression> <line-end>
+        <opt-whitespace> ::= \" \" <opt-whitespace> | \"\"
+        <expression>     ::= <list> | <list> <opt-whitespace> \"|\"
+                            <opt-whitespace> <expression>
+        <line-end>       ::= <opt-whitespace> <EOL> | <line-end> <line-end>
+        <list>           ::= <term> | <term> <opt-whitespace> <list>
+        <term>           ::= <literal> | \"<\" <rule-name> \">\"
+        <literal>        ::= '\"' <text1> '\"' | \"'\" <text2> \"'\"
+        <text1>          ::= \"\" | <character1> <text1>
+        <text2>          ::= \"\" | <character2> <text2>
+        <character>      ::= <letter> | <digit> | <symbol>
+        <letter>         ::= \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\"
+                            | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\"
+                            | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\"
+                            | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\"
+                            | \"Y\" | \"Z\" | \"a\" | \"b\" | \"c\" | \"d\"
+                            | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\"
+                            | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\"
+                            | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\"
+                            | \"w\" | \"x\" | \"y\" | \"z\"
 
-    #[test]
-    fn parse_from_bnf_for_bnf() {
-        // Modified version of BNF for BNF from
-        // https://en.wikipedia.org/wiki/Backus%E2%80%93Naur_form#Further_examples
-        let bnf_for_bnf: &str = "<syntax>        ::= <rule> | <rule> <syntax>
-            <rule>           ::= <opt-whitespace> \"<\" <rule-name> \">\"
-                                <opt-whitespace> \"::=\" <opt-whitespace>
-                                <expression> <line-end>
-            <opt-whitespace> ::= \" \" <opt-whitespace> | \"\"
-            <expression>     ::= <list> | <list> <opt-whitespace> \"|\"
-                                <opt-whitespace> <expression>
-            <line-end>       ::= <opt-whitespace> <EOL> | <line-end> <line-end>
-            <list>           ::= <term> | <term> <opt-whitespace> <list>
-            <term>           ::= <literal> | \"<\" <rule-name> \">\"
-            <literal>        ::= '\"' <text1> '\"' | \"'\" <text2> \"'\"
-            <text1>          ::= \"\" | <character1> <text1>
-            <text2>          ::= \"\" | <character2> <text2>
-            <character>      ::= <letter> | <digit> | <symbol>
-            <letter>         ::= \"A\" | \"B\" | \"C\" | \"D\" | \"E\" | \"F\"
-                                | \"G\" | \"H\" | \"I\" | \"J\" | \"K\" | \"L\"
-                                | \"M\" | \"N\" | \"O\" | \"P\" | \"Q\" | \"R\"
-                                | \"S\" | \"T\" | \"U\" | \"V\" | \"W\" | \"X\"
-                                | \"Y\" | \"Z\" | \"a\" | \"b\" | \"c\" | \"d\"
-                                | \"e\" | \"f\" | \"g\" | \"h\" | \"i\" | \"j\"
-                                | \"k\" | \"l\" | \"m\" | \"n\" | \"o\" | \"p\"
-                                | \"q\" | \"r\" | \"s\" | \"t\" | \"u\" | \"v\"
-                                | \"w\" | \"x\" | \"y\" | \"z\"
+        <digit>          ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\"
+                            | \"6\" | \"7\" | \"8\" | \"9\"
 
-            <digit>          ::= \"0\" | \"1\" | \"2\" | \"3\" | \"4\" | \"5\"
-                                | \"6\" | \"7\" | \"8\" | \"9\"
+        <symbol>         ::=  \"|\" | \" \" | \"-\" | \"!\" | \"#\" | \"$\"
+                            | \"%\" | \"&\" | \"(\" | \")\" | \"*\" | \"+\"
+                            | \",\" | \"-\" | \".\" | \"/\" | \":\" | \";\"
+                            |\">\" | \"=\" | \"<\" | \"?\" | \"@\" | \"[\"
+                            | \"\\\" | \"]\" | \"^\" | \"_\" | \"`\"
+                            | \"{{\" | \"}}\" | \"~\"
 
-            <symbol>         ::=  \"|\" | \" \" | \"-\" | \"!\" | \"#\" | \"$\"
-                                | \"%\" | \"&\" | \"(\" | \")\" | \"*\" | \"+\"
-                                | \",\" | \"-\" | \".\" | \"/\" | \":\" | \";\"
-                                |\">\" | \"=\" | \"<\" | \"?\" | \"@\" | \"[\"
-                                | \"\\\" | \"]\" | \"^\" | \"_\" | \"`\"
-                                | \"{{\" | \"}}\" | \"~\"
+        <character1>     ::= <character> | \"'\"
+        <character2>     ::= <character> | '\"'
+        <rule-name>      ::= <letter> | <rule-name> <rule-char>
+        <rule-char>      ::= <letter> | <digit> | \"-\"
+        <EOL>            ::= \"\n\"";
 
-            <character1>     ::= <character> | \"'\"
-            <character2>     ::= <character> | '\"'
-            <rule-name>      ::= <letter> | <rule-name> <rule-char>
-            <rule-char>      ::= <letter> | <digit> | \"-\"
-            <EOL>            ::= \"\n\"";
-
-        let grammar = bnf::Grammar::from_str(bnf_for_bnf);
-        assert!(grammar.is_ok(), "{:?} should be Ok", grammar);
-        let sentence = grammar.unwrap().generate();
-        assert!(sentence.is_ok());
-        let meta_grammar = bnf::Grammar::from_str(&sentence.unwrap());
-        assert!(meta_grammar.is_ok());
-    }
+    let grammar = bnf::Grammar::from_str(bnf_for_bnf);
+    assert!(grammar.is_ok(), "{:?} should be Ok", grammar);
+    let sentence = grammar.unwrap().generate();
+    assert!(sentence.is_ok());
+    let meta_grammar = bnf::Grammar::from_str(&sentence.unwrap());
+    assert!(meta_grammar.is_ok());
 }

--- a/tests/iterate.rs
+++ b/tests/iterate.rs
@@ -1,114 +1,111 @@
 extern crate bnf;
 
-#[cfg(test)]
-mod tests {
-    use bnf::{Grammar, Term};
+use bnf::{Grammar, Term};
 
-    #[test]
-    fn iterate_grammar() {
-        let dna_productions = "
-            <dna> ::= <base> | <base> <dna>
-            <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
+#[test]
+fn iterate_grammar() {
+    let dna_productions = "
+        <dna> ::= <base> | <base> <dna>
+        <base> ::= \"A\" | \"C\" | \"G\" | \"T\"";
 
-        let dna_grammar = Grammar::from_str(dna_productions).unwrap();
+    let dna_grammar = Grammar::from_str(dna_productions).unwrap();
 
-        let left_hand_terms: Vec<&Term> = dna_grammar
-            .productions_iter()
-            .map(|ref prod| &prod.lhs)
-            .collect();
+    let left_hand_terms: Vec<&Term> = dna_grammar
+        .productions_iter()
+        .map(|ref prod| &prod.lhs)
+        .collect();
 
-        // should be as many left hand terms as productions
-        assert_eq!(
-            dna_grammar.productions_iter().count(),
-            left_hand_terms.len()
+    // should be as many left hand terms as productions
+    assert_eq!(
+        dna_grammar.productions_iter().count(),
+        left_hand_terms.len()
+    );
+
+    let right_hand_terms: Vec<&Term> = dna_grammar
+        .productions_iter()
+        .flat_map(|prod| prod.rhs_iter())
+        .flat_map(|expr| expr.terms_iter())
+        .collect();
+
+    // check nonterminals are in left and right hand terms collection
+    for term in ["dna", "base"].into_iter() {
+        let term_string = String::from(*term);
+        let expected_nonterminal = Term::Nonterminal(term_string);
+
+        assert!(
+            left_hand_terms.contains(&&expected_nonterminal),
+            "{} was not in left hand terms",
+            expected_nonterminal
         );
 
-        let right_hand_terms: Vec<&Term> = dna_grammar
-            .productions_iter()
-            .flat_map(|prod| prod.rhs_iter())
-            .flat_map(|expr| expr.terms_iter())
-            .collect();
-
-        // check nonterminals are in left and right hand terms collection
-        for term in ["dna", "base"].into_iter() {
-            let term_string = String::from(*term);
-            let expected_nonterminal = Term::Nonterminal(term_string);
-
-            assert!(
-                left_hand_terms.contains(&&expected_nonterminal),
-                "{} was not in left hand terms",
-                expected_nonterminal
-            );
-
-            assert!(
-                right_hand_terms.contains(&&expected_nonterminal),
-                "{} was not in right hand terms",
-                expected_nonterminal
-            );
-        }
-
-        // any term which appears on the right but not left is a terminal
-        let only_right_terms: Vec<&Term> = right_hand_terms
-            .into_iter()
-            .filter(|term| !left_hand_terms.contains(term))
-            .collect();
-
-        // check terminals are only on right hand side
-        for term in ["A", "C", "G", "T"].into_iter() {
-            let term_string = String::from(*term);
-            let expected_terminal = Term::Terminal(term_string);
-
-            assert!(
-                only_right_terms.contains(&&expected_terminal),
-                "{} was not in left hand terms",
-                expected_terminal
-            );
-        }
+        assert!(
+            right_hand_terms.contains(&&expected_nonterminal),
+            "{} was not in right hand terms",
+            expected_nonterminal
+        );
     }
 
-    #[test]
-    fn mutably_iterate_grammar() {
-        let dna_productions = "
-            <dna> ::= <dna> | <base> <dna>;
-            <base> ::= \"A\" | \"C\" | \"G\" | \"T\";";
+    // any term which appears on the right but not left is a terminal
+    let only_right_terms: Vec<&Term> = right_hand_terms
+        .into_iter()
+        .filter(|term| !left_hand_terms.contains(term))
+        .collect();
 
-        let mut dna_grammar = Grammar::from_str(dna_productions).unwrap();
+    // check terminals are only on right hand side
+    for term in ["A", "C", "G", "T"].into_iter() {
+        let term_string = String::from(*term);
+        let expected_terminal = Term::Terminal(term_string);
 
-        // scope mutable borrow
-        {
-            let terminals = dna_grammar
-                .productions_iter_mut()
-                .flat_map(|prod| prod.rhs_iter_mut())
-                .flat_map(|expr| expr.terms_iter_mut())
-                .filter(|&&mut ref term| match *term {
-                    Term::Terminal(_) => true,
-                    _ => false,
-                });
+        assert!(
+            only_right_terms.contains(&&expected_terminal),
+            "{} was not in left hand terms",
+            expected_terminal
+        );
+    }
+}
 
-            // transform all terminals to "Z"
-            for term in terminals {
-                *term = Term::Terminal(String::from("Z"));
-            }
-        }
+#[test]
+fn mutably_iterate_grammar() {
+    let dna_productions = "
+        <dna> ::= <dna> | <base> <dna>;
+        <base> ::= \"A\" | \"C\" | \"G\" | \"T\";";
 
-        // get another iterator to check work
-        let are_all_terminals_z = dna_grammar
-            .productions_iter()
-            .flat_map(|prod| prod.rhs_iter())
-            .flat_map(|expr| expr.terms_iter())
-            .filter(|&term| match *term {
+    let mut dna_grammar = Grammar::from_str(dna_productions).unwrap();
+
+    // scope mutable borrow
+    {
+        let terminals = dna_grammar
+            .productions_iter_mut()
+            .flat_map(|prod| prod.rhs_iter_mut())
+            .flat_map(|expr| expr.terms_iter_mut())
+            .filter(|&&mut ref term| match *term {
                 Term::Terminal(_) => true,
-                _ => false,
-            })
-            .all(|term| match *term {
-                Term::Terminal(ref s) => *s == String::from("Z"),
                 _ => false,
             });
 
-        assert!(
-            are_all_terminals_z,
-            "all terminals in {} were not \"Z\"",
-            dna_grammar
-        );
+        // transform all terminals to "Z"
+        for term in terminals {
+            *term = Term::Terminal(String::from("Z"));
+        }
     }
+
+    // get another iterator to check work
+    let are_all_terminals_z = dna_grammar
+        .productions_iter()
+        .flat_map(|prod| prod.rhs_iter())
+        .flat_map(|expr| expr.terms_iter())
+        .filter(|&term| match *term {
+            Term::Terminal(_) => true,
+            _ => false,
+        })
+        .all(|term| match *term {
+            Term::Terminal(ref s) => *s == String::from("Z"),
+            _ => false,
+        });
+
+    assert!(
+        are_all_terminals_z,
+        "all terminals in {} were not \"Z\"",
+        dna_grammar
+    );
 }


### PR DESCRIPTION
As described in the [rust book](https://doc.rust-lang.org/book/second-edition/ch11-03-test-organization.html#the-tests-directory), the tests directory is already implicitly for tests, and thus does not need the usual `test` module which unit tests use.