### PR TITLE
Test to_string and from_str reflexive property

### DIFF
--- a/src/term.rs
+++ b/src/term.rs
@@ -48,15 +48,16 @@ impl fmt::Display for Term {
 mod tests {
     extern crate quickcheck;
 
-    use self::quickcheck::{Arbitrary, Gen, QuickCheck, StdGen, TestResult};
+    use self::quickcheck::{Arbitrary, Gen, QuickCheck, TestResult};
     use super::*;
 
     impl Arbitrary for Term {
         fn arbitrary<G: Gen>(g: &mut G) -> Self {
+            let mut term = String::arbitrary(g);
             if bool::arbitrary(g) {
-                Term::Nonterminal(String::arbitrary(g))
+                term = term.chars().filter(|&c| (c != '>')).collect();
+                Term::Nonterminal(term)
             } else {
-                let mut term = String::arbitrary(g);
                 if term.contains('"') {
                     term = term.chars().filter(|&c| c != '\'').collect();
                 } else if term.contains('\'') {
@@ -74,6 +75,11 @@ mod tests {
             Ok(from_term) => TestResult::from_bool(from_term == term),
             _ => TestResult::error(format!("{} to string and back should be safe", term)),
         }
+    }
+
+    #[test]
+    fn term_to_string_and_back() {
+        QuickCheck::new().quickcheck(prop_to_string_and_back as fn(Term) -> TestResult)
     }
 
     #[test]

--- a/src/term.rs
+++ b/src/term.rs
@@ -78,7 +78,7 @@ mod tests {
     }
 
     #[test]
-    fn term_to_string_and_back() {
+    fn to_string_and_back() {
         QuickCheck::new().quickcheck(prop_to_string_and_back as fn(Term) -> TestResult)
     }
 


### PR DESCRIPTION
Theoretically any Grammar/Production/Expression/Term which is converted to string, and then back should maintain the same value. In order to test this property, `quickcheck::arbitrary` was implemented for each type, but only if building for tests. Hopefully these arbitrary values will be useful for future property tests. The tests using arbitrary Grammar/Production ran a little slow so the # of tests and size limit were restricted. According to travis, these tests added ~1 minute of build/test time.